### PR TITLE
Fixes nirev/synology-tailscale#16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  create:
+  release:
+    types: # This configuration does not affect the page_build event above
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run makescript
+        run: make
+      - name: Release
+        uses: fnkr/github-action-ghr@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GHR_PATH: spks/
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Synology NAS package for Tailscale based on precompiled static binaries.
 
+![CI](https://github.com/nirev/synology-tailscale/workflows/CI/badge.svg)
+
 ## Disclaimer
 
 You use everything here at your own risk. I am not responsible if this


### PR DESCRIPTION
Build on push to master. Only creates a release when a tag is used.