### PR TITLE
update to tailscale v1.1.335 (unstable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.1.335 (2020-09-11)
+
+- tailscale v1.1.335 static binaries (unstable)
+  this version defaults to netfilter disabled for Synology devices as a
+  workaround for missing netfilter modules in Synology DSM ([tailscale/tailscale#750](https://github.com/tailscale/tailscale/pull/750))
+
 ## v0.98-0 (2020-06-09)
 
 - tailscale v0.98-0 static binaries

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAILSCALE_VERSION="0.98-0"
+TAILSCALE_VERSION="1.1.335"
 SPK_BUILD="1"
 
 .PHONY: tailscale-% clean purge

--- a/build-package.sh
+++ b/build-package.sh
@@ -7,7 +7,7 @@ ARCH=$2
 SPK_BUILD=$3
 
 download_tailscale() {
-  local base_url="https://pkgs.tailscale.com/stable"
+  local base_url="https://pkgs.tailscale.com/unstable"
   local pkg_name="tailscale_${TAILSCALE_VERSION}_${ARCH}.tgz"
   local src_pkg="${base_url}/${pkg_name}"
   local dest_pkg="_tailscale/${pkg_name}"


### PR DESCRIPTION
This version has a workaround for missing netfilter modules in DSM by running tailscale with `--netfilter-mode=off` in Synology devices

Reference: 
- https://github.com/tailscale/tailscale/pull/750
- https://github.com/tailscale/tailscale/issues/451
